### PR TITLE
Read zoom and attribution config from /<style>/info.json

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -1,10 +1,12 @@
+var matchStyle, style, matchScale, scale, scalex, xhr, map;
+
 // Allow user to change style via the ?s=xxx URL parameter
 // Uses "osm-intl" as the default style
-var matchStyle = location.search.match(/s=([^&\/]*)/);
-var style = (matchStyle && matchStyle[1]) || 'osm-intl';
+matchStyle = location.search.match(/s=([^&\/]*)/);
+style = (matchStyle && matchStyle[1]) || 'osm-intl';
 
 // Create a map
-var map = L.map('map').setView([40.75, -73.96], 4);
+map = L.map('map').setView([40.75, -73.96], 4);
 map.attributionControl.setPrefix('');
 
 function bracketDevicePixelRatio() {
@@ -19,24 +21,74 @@ function bracketDevicePixelRatio() {
     return brackets[brackets.length - 1];
 }
 
-var matchScale = location.search.match(/scale=([.0-9]*)/);
-var scale = (matchScale && parseFloat(matchScale[1])) || bracketDevicePixelRatio();
-var scalex = (scale === 1) ? '' : ('@' + scale + 'x');
+/**
+ * Finishes setting up the map
+ *
+ * @param {Object|null} config Config object
+ * @param string [config.attribution] Attribution text to show in footer; see below for default
+ * @param number [config.maxzoom=18] Maximum zoom level
+ */
+function setupMap( config ) {
+    var key, layerSettings, defaultSettings,
+        query = '',
+        matchLang = location.search.match(/lang=([-_a-zA-Z]+)/);
 
-// Add a map layer
-L.tileLayer(style + '/{z}/{x}/{y}' + scalex + '.png', {
-    maxZoom: 18,
-    attribution: 'Map data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>',
-    id: 'map-01'
-}).addTo(map);
+    defaultSettings = {
+        maxzoom: 18,
 
-// Add a km/miles scale
-L.control.scale().addTo(map);
+        // TODO: This is UI text, and needs to be translatable.
+        attribution: 'Map data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
+    };
 
-// Update the zoom level label
-map.on('zoomend', function () {
-    document.getElementById('zoom-level').innerHTML = 'Zoom Level: ' + map.getZoom();
-});
+    if (matchLang) {
+        query = '?lang=' + matchLang[1];
+    }
+    config = config || {};
 
-// Add current location to URL hash
-var hash = new L.Hash(map);
+    layerSettings = {
+        maxZoom: config.maxzoom !== undefined ? config.maxzoom : defaultSettings.maxzoom,
+
+        // TODO: This is UI text, and needs to be translatable.
+        attribution: config.attribution !== undefined ? config.attribution : defaultSettings.attribution,
+
+        id: 'map-01'
+    };
+
+    // Add a map layer
+    L.tileLayer(style + '/{z}/{x}/{y}' + scalex + '.png' + query, layerSettings).addTo(map);
+
+    // Add a km/miles scale
+    L.control.scale().addTo(map);
+
+    // Update the zoom level label
+    map.on('zoomend', function () {
+        document.getElementById('zoom-level').innerHTML = 'Zoom Level: ' + map.getZoom();
+    });
+
+    // Add current location to URL hash
+    new L.Hash(map);
+}
+
+matchScale = location.search.match(/scale=([.0-9]*)/);
+scale = (matchScale && parseFloat(matchScale[1])) || bracketDevicePixelRatio();
+scalex = (scale === 1) ? '' : ('@' + scale + 'x');
+
+xhr = new XMLHttpRequest();
+xhr.addEventListener('load', function () {
+    var config;
+
+    try {
+        config = JSON.parse( this.responseText );
+    } catch ( e ) {
+        config = null;
+    }
+
+    setupMap( config );
+
+} );
+xhr.addEventListener('error', function () {
+    setupMap( null );
+} );
+
+xhr.open('GET', '/' + style + '/info.json' );
+xhr.send();


### PR DESCRIPTION
This allows different installs to use their own setting while
reducing hard-coding.

When you have URL parameters, there is currently a flash where you see
the default map before it loads the settings and zooms.  The settings
could be cached in localStorage to mitigate that.

This changes the default max zoom (used only if the /info.json request
fails) to 18.  This is on the theory that 18 is safe if 20 is
available, but not vice-versa.

Bug: T186780

Updated version of https://github.com/kartotherian/server/pull/4 .