### PR TITLE
Force linting of es5 file

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-config-kartotherian": "^0.0.3",
+    "eslint-config-wikimedia": "^0.5.0",
     "eslint-plugin-import": "^2.9.0",
     "grunt": "^1.0.2",
     "grunt-contrib-watch": "1.0.0",

--- a/static/.eslintrc.js
+++ b/static/.eslintrc.js
@@ -1,9 +1,16 @@
 module.exports = {
-  "extends": "../.eslintrc.js",
+  "extends": "wikimedia",
   "env": {
     "node": false,
     "es6": false,
     "browser": true,
+  },
+  "rules": {
+    "indent": ["error", 2]
+  },
+  "parserOptions": {
+    sourceType: 'script',
+    ecmaVersion: 5,
   },
   "globals": {
     "L": false

--- a/static/main.js
+++ b/static/main.js
@@ -1,56 +1,51 @@
-(function (location) { // eslint-disable-line func-names
+( function ( location ) { // eslint-disable-line func-names
   // Allow user to change style via the ?s=xxx URL parameter
   // Uses "osm-intl" as the default style
-  const matchStyle = location.search.match(/s=([^&/]*)/);
-  const matchScale = location.search.match(/scale=([.0-9]*)/);
-  const matchLang = location.search.match(/lang=([-_a-zA-Z]+)/);
+  var matchStyle = location.search.match( /s=([^&/]*)/ ),
+    matchScale = location.search.match( /scale=([.0-9]*)/ ),
+    matchLang = location.search.match( /lang=([-_a-zA-Z]+)/ ),
+    bracketDevicePixelRatio = function bracketDevicePixelRatio() {
+      var i, scale,
+        brackets = [ 1, 1.3, 1.5, 2, 2.6, 3 ],
+        baseRatio = window.devicePixelRatio || 1;
 
-  const bracketDevicePixelRatio = function bracketDevicePixelRatio() {
-    const brackets = [1, 1.3, 1.5, 2, 2.6, 3];
-    const baseRatio = window.devicePixelRatio || 1;
+      for ( i = 0; i < brackets.length; i++ ) {
+        scale = brackets[ i ];
 
-    let i;
-    let scale;
-
-    for (i = 0; i < brackets.length; i += 1) {
-      scale = brackets[i];
-
-      if (scale >= baseRatio || (baseRatio - scale) < 0.1) {
-        return scale;
+        if ( scale >= baseRatio || ( baseRatio - scale ) < 0.1 ) {
+          return scale;
+        }
       }
-    }
-    return brackets[brackets.length - 1];
-  };
-
-  const style = (matchStyle && matchStyle[1]) || 'osm-intl';
-  const scale = (matchScale && parseFloat(matchScale[1])) || bracketDevicePixelRatio();
-  const scalex = (scale === 1) ? '' : (`@${scale}x`);
-  const map = L.map('map').setView([40.75, -73.96], 4);
-
-  let query = '';
+      return brackets[ brackets.length - 1 ];
+    },
+    style = ( matchStyle && matchStyle[ 1 ] ) || 'osm-intl',
+    scale = ( matchScale && parseFloat( matchScale[ 1 ] ) ) || bracketDevicePixelRatio(),
+    scalex = ( scale === 1 ) ? '' : ( scale + 'x' ),
+    map = L.map( 'map' ).setView( [ 40.75, -73.96 ], 4 ),
+    query = '';
 
   // Create a map
-  map.attributionControl.setPrefix('');
+  map.attributionControl.setPrefix( '' );
 
-  if (matchLang) {
-    query = `?lang=${matchLang[1]}`;
+  if ( matchLang ) {
+    query = '?lang=' + matchLang[ 1 ];
   }
 
   // Add a map layer
-  L.tileLayer(`${style}/{z}/{x}/{y}${scalex}.png${query}`, {
+  L.tileLayer( style + '/{z}/{x}/{y}' + scalex + 'png' + query, {
     maxZoom: 20,
     attribution: 'Map data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>',
-    id: 'map-01',
-  }).addTo(map);
+    id: 'map-01'
+  } ).addTo( map );
 
   // Add a km/miles scale
-  L.control.scale().addTo(map);
+  L.control.scale().addTo( map );
 
   // Update the zoom level label
-  map.on('zoomend', () => {
-    document.getElementById('zoom-level').innerHTML = `Zoom Level: ${map.getZoom()}`;
-  });
+  map.on( 'zoomend', function zoomend() {
+    document.getElementById( 'zoom-level' ).innerHTML = 'Zoom Level: ' + map.getZoom();
+  } );
 
   // Add current location to URL hash
-  const hash = new L.Hash(map); // eslint-disable-line one-var,no-unused-vars
-}(window.location));
+  var hash = new L.Hash( map ); // eslint-disable-line vars-on-top,one-var,no-unused-vars
+}( window.location ) );


### PR DESCRIPTION
Since the airbnb-base file is completely configured for es6, even
canceling the environment param 'node' doesn't help, as all the
rules still apply. We have to make sure the browser-facing file is
properly linted to work in supported browsers. For that purpose,
the ruleset for wikimedia is used for the es5 file alone, for the
sake of having a base lint that allows es5 rules.

Fixes #7