### PR TITLE
Transform png to png8:m=h in opts.format but leave params.format alon…

### DIFF
--- a/lib/tiles.js
+++ b/lib/tiles.js
@@ -79,12 +79,9 @@ function requestHandler(req, res, next) {
       y: params.y,
     };
     if (params.format !== 'pbf') {
-      if (params.format === 'png') {
-        // Ensure that PNGs are not 32bit
-        // TODO: this should be source-configurable
-        params.format = 'png8:m=h';
-      }
-      opts.format = params.format;
+      // Ensure that PNGs are not 32bit
+      // TODO: this should be source-configurable
+      opts.format = params.format === 'png' ? 'png8:m=h' : params.format;
       if (params.scale) {
         opts.scale = params.scale;
       }


### PR DESCRIPTION
…e since it is also used to record metrics.